### PR TITLE
🎯 簡化連勝賽制系統 v1.4.0 - 視覺化比賽流程

### DIFF
--- a/src/components/GameArena.css
+++ b/src/components/GameArena.css
@@ -1,135 +1,377 @@
-.arena-section {
-  background: linear-gradient(45deg, #ff6b6b, #ee5a52);
+/* Enhanced Game Arena Styles with Visual Flow */
+
+.game-arena {
+  background: rgba(255, 255, 255, 0.1);
   border-radius: 15px;
   padding: 20px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   color: white;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
 }
 
-.arena-section::before {
-  content: '';
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: repeating-linear-gradient(
-    45deg,
-    transparent,
-    transparent 10px,
-    rgba(255, 255, 255, 0.1) 10px,
-    rgba(255, 255, 255, 0.1) 20px
-  );
-  animation: movePattern 20s linear infinite;
-}
-
-@keyframes movePattern {
-  0% { transform: translateX(-50px) translateY(-50px); }
-  100% { transform: translateX(0) translateY(0); }
-}
-
-.section-title {
-  font-size: 1.3em;
-  font-weight: bold;
-  margin-bottom: 15px;
-  color: white;
-  position: relative;
-  z-index: 1;
-}
-
-.battle-area {
+.game-arena.enhanced {
+  min-height: 400px;
   display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.game-arena.finished {
+  text-align: center;
   justify-content: center;
   align-items: center;
-  gap: 30px;
-  margin: 20px 0;
-  position: relative;
-  z-index: 1;
+  display: flex;
 }
 
-.fighter {
-  background: rgba(255, 255, 255, 0.9);
-  color: #333;
-  padding: 20px;
+/* Header */
+.arena-header {
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  padding-bottom: 15px;
+}
+
+.arena-header h3 {
+  margin: 0 0 10px 0;
+  font-size: 1.5em;
+}
+
+.match-info {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 5px 15px;
   border-radius: 15px;
-  font-weight: bold;
-  font-size: 1.2em;
-  min-width: 120px;
+  display: inline-block;
+  font-size: 0.9em;
+}
+
+/* Main Arena Layout */
+.arena-main {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 20px;
+  align-items: start;
+  flex: 1;
+}
+
+/* Player Sections */
+.player-section {
+  position: relative;
+}
+
+.player-card {
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 15px;
+  padding: 20px;
   text-align: center;
   transition: all 0.3s ease;
-  animation: pulse 2s infinite;
-  position: relative;
-}
-
-/* Clickable fighter styles */
-.fighter.clickable {
   cursor: pointer;
-  user-select: none;
+  position: relative;
+  overflow: visible;
 }
 
-.fighter.clickable:hover {
-  background: rgba(46, 204, 113, 0.9);
-  color: white;
-  transform: scale(1.1);
-  box-shadow: 0 5px 15px rgba(46, 204, 113, 0.4);
+.player-card.clickable:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.5);
+  transform: translateY(-5px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
 }
 
-.fighter.clickable:active {
-  transform: scale(1.05);
+.player-card.preview-active {
+  background: rgba(76, 175, 80, 0.3);
+  border-color: #4CAF50;
+  transform: translateY(-5px);
+  box-shadow: 0 10px 25px rgba(76, 175, 80, 0.4);
 }
 
-.fighter.disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.player-info h4 {
+  margin: 0 0 15px 0;
+  font-size: 1.3em;
+  color: #fff;
 }
 
-.fighter.disabled:hover {
-  background: rgba(255, 255, 255, 0.9);
-  color: #333;
-  transform: none;
-  box-shadow: none;
+.player-stats {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
 }
 
-/* Click hint text */
-.click-hint {
-  font-size: 0.8em;
-  margin-top: 5px;
-  opacity: 0.7;
-  font-weight: normal;
-  color: #666;
-}
-
-.fighter.clickable:hover .click-hint {
-  color: rgba(255, 255, 255, 0.9);
-  opacity: 1;
-}
-
-@keyframes pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.05); }
-}
-
-.vs-indicator {
-  font-size: 3em;
-  font-weight: bold;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+.player-stats span {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 5px 10px;
+  border-radius: 10px;
+  font-size: 0.9em;
+  flex: 1;
 }
 
 .rest-option {
-  background: #9b59b6;
-  color: white;
-  padding: 15px;
-  border-radius: 10px;
-  margin: 15px 0;
-  text-align: center;
-  animation: glow 2s infinite alternate;
-  position: relative;
-  z-index: 1;
+  margin-top: 10px;
 }
 
-@keyframes glow {
-  from { box-shadow: 0 0 10px rgba(155, 89, 182, 0.5); }
-  to { box-shadow: 0 0 20px rgba(155, 89, 182, 0.8); }
+.rest-badge {
+  background: linear-gradient(45deg, #FF6B6B, #4ECDC4);
+  color: white;
+  padding: 5px 12px;
+  border-radius: 20px;
+  font-size: 0.8em;
+  font-weight: bold;
+  animation: pulse 2s infinite;
+}
+
+.click-hint {
+  position: absolute;
+  bottom: -30px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 5px 10px;
+  border-radius: 15px;
+  font-size: 0.8em;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.player-card:hover .click-hint {
+  opacity: 1;
+}
+
+/* VS Section */
+.vs-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 20px 0;
+}
+
+.vs-icon {
+  font-size: 2.5em;
+  font-weight: bold;
+  background: linear-gradient(45deg, #667eea, #764ba2);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 10px;
+}
+
+.match-status {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 8px 15px;
+  border-radius: 20px;
+  font-size: 0.9em;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* Flow Preview */
+.flow-preview {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.95);
+  border: 2px solid #4CAF50;
+  border-radius: 15px;
+  padding: 15px;
+  margin-top: 10px;
+  z-index: 100;
+  animation: slideDown 0.3s ease;
+}
+
+.flow-preview h5 {
+  margin: 0 0 15px 0;
+  color: #4CAF50;
+  font-size: 1em;
+  text-align: center;
+}
+
+.flow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.flow-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.9em;
+}
+
+.flow-step.winner {
+  background: rgba(76, 175, 80, 0.2);
+  border-left: 3px solid #4CAF50;
+}
+
+.flow-step.loser {
+  background: rgba(255, 152, 0, 0.2);
+  border-left: 3px solid #FF9800;
+}
+
+.flow-step.next {
+  background: rgba(33, 150, 243, 0.2);
+  border-left: 3px solid #2196F3;
+}
+
+.flow-step .icon {
+  font-size: 1.2em;
+  min-width: 20px;
+}
+
+.flow-step .detail {
+  font-size: 0.8em;
+  opacity: 0.8;
+  margin-left: auto;
+}
+
+.rest-choice {
+  margin-top: 15px;
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  padding-top: 15px;
+}
+
+.rest-btn {
+  background: linear-gradient(45deg, #FF6B6B, #4ECDC4);
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 25px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-size: 0.9em;
+}
+
+.rest-btn:hover {
+  transform: scale(1.05);
+  box-shadow: 0 5px 15px rgba(255, 107, 107, 0.4);
+}
+
+/* Next Player Indicator */
+.next-player-indicator {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  padding: 15px;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 15px;
+}
+
+.next-player-indicator .label {
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.next-player-indicator .next-player {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 5px 15px;
+  border-radius: 15px;
+  font-weight: bold;
+  color: #4CAF50;
+}
+
+/* Animations */
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .arena-main {
+    grid-template-columns: 1fr;
+    gap: 15px;
+  }
+  
+  .vs-section {
+    order: -1;
+    padding: 10px 0;
+  }
+  
+  .vs-icon {
+    font-size: 2em;
+  }
+  
+  .player-card {
+    padding: 15px;
+  }
+  
+  .flow-preview {
+    position: relative;
+    margin-top: 15px;
+  }
+  
+  .next-player-indicator {
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .game-arena.enhanced {
+    padding: 15px;
+  }
+  
+  .player-card {
+    padding: 12px;
+  }
+  
+  .player-info h4 {
+    font-size: 1.1em;
+  }
+  
+  .player-stats {
+    flex-direction: column;
+    gap: 5px;
+  }
+  
+  .flow-preview {
+    padding: 12px;
+  }
+  
+  .flow-step {
+    padding: 6px 10px;
+    font-size: 0.8em;
+  }
+}
+
+/* Arena Message (for waiting/finished states) */
+.arena-message {
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.arena-message h3 {
+  margin: 0 0 10px 0;
+  font-size: 1.8em;
+}
+
+.arena-message p {
+  margin: 0;
+  opacity: 0.8;
+  font-size: 1.1em;
 }

--- a/src/components/GameArena.js
+++ b/src/components/GameArena.js
@@ -1,48 +1,238 @@
-import React from 'react';
+/**
+ * Enhanced Game Arena with Visual Flow - Streak Tournament
+ * Shows clear visual representation of what happens when each player wins/loses
+ */
+
+import React, { useState } from 'react';
 import './GameArena.css';
 
-const GameArena = ({ currentFighters, showRestOption, streakWinner, onPlayerClick }) => {
-  
-  // Handle player click for victory declaration
-  const handlePlayerClick = (playerName) => {
-    if (onPlayerClick && !showRestOption && currentFighters[0] && currentFighters[1]) {
-      onPlayerClick(playerName);
+const GameArena = ({ 
+  currentMatch, 
+  onDeclareWinner, 
+  canTakeRest, 
+  onTakeRest, 
+  isGameFinished,
+  players,
+  nextPlayerInQueue 
+}) => {
+  const [showFlowPreview, setShowFlowPreview] = useState(null);
+
+  if (!currentMatch || !currentMatch.player1 || !currentMatch.player2) {
+    return (
+      <div className="game-arena">
+        <div className="arena-message">
+          <h3>等待比賽開始...</h3>
+        </div>
+      </div>
+    );
+  }
+
+  if (isGameFinished) {
+    return (
+      <div className="game-arena finished">
+        <div className="arena-message">
+          <h3>🏆 比賽結束</h3>
+          <p>查看最終排名</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { player1, player2 } = currentMatch;
+  const player1CanRest = canTakeRest(player1.name);
+  const player2CanRest = canTakeRest(player2.name);
+
+  // Get next player for visual preview
+  const getNextPlayerName = () => {
+    if (nextPlayerInQueue) {
+      return nextPlayerInQueue.name;
     }
+    return '無等候選手';
   };
 
+  // Handle player selection with visual feedback
+  const handlePlayerClick = (player) => {
+    onDeclareWinner(player.name);
+  };
+
+  // Handle rest selection
+  const handleRestClick = (player) => {
+    onTakeRest(player.name);
+  };
+
+  // Preview what happens when player wins
+  const getWinPreview = (winner, loser) => {
+    const nextPlayer = getNextPlayerName();
+    return {
+      winner: {
+        action: winner.currentStreak + 1 >= (players.length - 1) && 
+                (winner.currentStreak + 1) % (players.length - 1) === 0 ? 
+                '可選擇休息或繼續' : '留場繼續',
+        streak: winner.currentStreak + 1,
+        canRest: winner.currentStreak + 1 >= (players.length - 1) && 
+                (winner.currentStreak + 1) % (players.length - 1) === 0
+      },
+      loser: {
+        action: '排隊等候',
+        nextOpponent: nextPlayer !== '無等候選手' ? nextPlayer : '等候其他選手'
+      },
+      nextMatch: nextPlayer !== '無等候選手' ? 
+        `${winner.name} vs ${nextPlayer}` : 
+        '等候選手返場'
+    };
+  };
+
+  const player1WinPreview = getWinPreview(player1, player2);
+  const player2WinPreview = getWinPreview(player2, player1);
+
   return (
-    <div className="arena-section">
-      <h3 className="section-title">⚔️ 競技場</h3>
-      <div className="battle-area">
-        <div 
-          className={`fighter ${currentFighters[0] ? 'clickable' : ''} ${showRestOption ? 'disabled' : ''}`}
-          onClick={() => currentFighters[0] && handlePlayerClick(currentFighters[0].name)}
-          title={currentFighters[0] && !showRestOption ? `點擊讓 ${currentFighters[0].name} 獲勝` : ''}
-        >
-          {currentFighters[0] ? currentFighters[0].name : '等待選手'}
-          {currentFighters[0] && !showRestOption && (
-            <div className="click-hint">點擊獲勝</div>
+    <div className="game-arena enhanced">
+      <div className="arena-header">
+        <h3>🥊 比賽進行中</h3>
+        <div className="match-info">
+          <span>第 {(players.reduce((sum, p) => sum + p.totalWins, 0)) + 1} 場</span>
+        </div>
+      </div>
+
+      <div className="arena-main">
+        {/* Player 1 Section */}
+        <div className="player-section left">
+          <div 
+            className={`player-card clickable ${showFlowPreview === 'player1' ? 'preview-active' : ''}`}
+            onClick={() => handlePlayerClick(player1)}
+            onMouseEnter={() => setShowFlowPreview('player1')}
+            onMouseLeave={() => setShowFlowPreview(null)}
+          >
+            <div className="player-info">
+              <h4>{player1.name}</h4>
+              <div className="player-stats">
+                <span className="score">分數: {player1.score}</span>
+                <span className="streak">連勝: {player1.currentStreak}</span>
+              </div>
+            </div>
+            
+            {player1CanRest && (
+              <div className="rest-option">
+                <span className="rest-badge">可休息 +1分</span>
+              </div>
+            )}
+            
+            <div className="click-hint">點擊宣布勝利</div>
+          </div>
+
+          {/* Flow Preview for Player 1 Win */}
+          {showFlowPreview === 'player1' && (
+            <div className="flow-preview">
+              <h5>如果 {player1.name} 獲勝:</h5>
+              <div className="flow-steps">
+                <div className="flow-step winner">
+                  <span className="icon">🏆</span>
+                  <span>{player1.name}: {player1WinPreview.winner.action}</span>
+                  <span className="detail">連勝: {player1WinPreview.winner.streak}</span>
+                </div>
+                <div className="flow-step loser">
+                  <span className="icon">📝</span>
+                  <span>{player2.name}: {player1WinPreview.loser.action}</span>
+                </div>
+                <div className="flow-step next">
+                  <span className="icon">⚡</span>
+                  <span>下一場: {player1WinPreview.nextMatch}</span>
+                </div>
+              </div>
+              
+              {player1WinPreview.winner.canRest && (
+                <div className="rest-choice">
+                  <button 
+                    className="rest-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRestClick(player1);
+                    }}
+                  >
+                    選擇休息 (+1分)
+                  </button>
+                </div>
+              )}
+            </div>
           )}
         </div>
-        <div className="vs-indicator">VS</div>
-        <div 
-          className={`fighter ${currentFighters[1] ? 'clickable' : ''} ${showRestOption ? 'disabled' : ''}`}
-          onClick={() => currentFighters[1] && handlePlayerClick(currentFighters[1].name)}
-          title={currentFighters[1] && !showRestOption ? `點擊讓 ${currentFighters[1].name} 獲勝` : ''}
-        >
-          {currentFighters[1] ? currentFighters[1].name : '等待選手'}
-          {currentFighters[1] && !showRestOption && (
-            <div className="click-hint">點擊獲勝</div>
+
+        {/* VS Section */}
+        <div className="vs-section">
+          <div className="vs-icon">VS</div>
+          <div className="match-status">
+            <span>點擊選手宣布勝利</span>
+          </div>
+        </div>
+
+        {/* Player 2 Section */}
+        <div className="player-section right">
+          <div 
+            className={`player-card clickable ${showFlowPreview === 'player2' ? 'preview-active' : ''}`}
+            onClick={() => handlePlayerClick(player2)}
+            onMouseEnter={() => setShowFlowPreview('player2')}
+            onMouseLeave={() => setShowFlowPreview(null)}
+          >
+            <div className="player-info">
+              <h4>{player2.name}</h4>
+              <div className="player-stats">
+                <span className="score">分數: {player2.score}</span>
+                <span className="streak">連勝: {player2.currentStreak}</span>
+              </div>
+            </div>
+            
+            {player2CanRest && (
+              <div className="rest-option">
+                <span className="rest-badge">可休息 +1分</span>
+              </div>
+            )}
+            
+            <div className="click-hint">點擊宣布勝利</div>
+          </div>
+
+          {/* Flow Preview for Player 2 Win */}
+          {showFlowPreview === 'player2' && (
+            <div className="flow-preview">
+              <h5>如果 {player2.name} 獲勝:</h5>
+              <div className="flow-steps">
+                <div className="flow-step winner">
+                  <span className="icon">🏆</span>
+                  <span>{player2.name}: {player2WinPreview.winner.action}</span>
+                  <span className="detail">連勝: {player2WinPreview.winner.streak}</span>
+                </div>
+                <div className="flow-step loser">
+                  <span className="icon">📝</span>
+                  <span>{player1.name}: {player2WinPreview.loser.action}</span>
+                </div>
+                <div className="flow-step next">
+                  <span className="icon">⚡</span>
+                  <span>下一場: {player2WinPreview.nextMatch}</span>
+                </div>
+              </div>
+              
+              {player2WinPreview.winner.canRest && (
+                <div className="rest-choice">
+                  <button 
+                    className="rest-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRestClick(player2);
+                    }}
+                  >
+                    選擇休息 (+1分)
+                  </button>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>
-      
-      {showRestOption && (
-        <div className="rest-option">
-          <strong>🏆 完成一輪挑戰！</strong><br />
-          {streakWinner?.name} 可選擇休息得 1 分或繼續比賽
-        </div>
-      )}
+
+      {/* Next Player Indicator */}
+      <div className="next-player-indicator">
+        <span className="label">下一位上場:</span>
+        <span className="next-player">{getNextPlayerName()}</span>
+      </div>
     </div>
   );
 };

--- a/src/components/GameRules.js
+++ b/src/components/GameRules.js
@@ -1,18 +1,47 @@
+/**
+ * Simplified Game Rules Component - Streak Tournament Only
+ * Clear display of streak tournament rules
+ */
+
 import React from 'react';
 import './GameRules.css';
 
-const GameRules = ({ playerCount = 4 }) => {
-  const requiredWins = playerCount - 1; // Dynamic win requirement
+const GameRules = ({ playerCount = 4, restRequirement = 3, compact = false }) => {
+  if (compact) {
+    return (
+      <div className="rules compact">
+        <h4 className="rules-title">📋 規則速覽</h4>
+        <div className="rules-compact-list">
+          <div className="rule-compact">
+            <span className="rule-icon">🏆</span>
+            <span>連勝 {restRequirement} 場可休息</span>
+          </div>
+          <div className="rule-compact">
+            <span className="rule-icon">⭐</span>
+            <span>休息獲得額外 1 分</span>
+          </div>
+          <div className="rule-compact">
+            <span className="rule-icon">🔄</span>
+            <span>勝者留場，敗者排隊</span>
+          </div>
+          <div className="rule-compact">
+            <span className="rule-icon">↶</span>
+            <span>支援無限撤銷</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="rules">
-      <h3 className="rules-title">📋 比賽規則</h3>
+      <h3 className="rules-title">📋 連勝賽制規則</h3>
       <div className="rules-grid">
         <div className="rule-item">
           <div className="rule-icon">🥊</div>
           <div className="rule-content">
             <h4>比賽機制</h4>
-            <p>{playerCount}人循環一對一單挑，勝者留場，輸者下場排隊</p>
+            <p>{playerCount}人循環一對一單挑，勝者留場，敗者下場排隊</p>
           </div>
         </div>
         
@@ -27,12 +56,9 @@ const GameRules = ({ playerCount = 4 }) => {
         <div className="rule-item">
           <div className="rule-icon">🔥</div>
           <div className="rule-content">
-            <h4>連勝獎勵</h4>
+            <h4>連勝休息</h4>
             <p>
-              {playerCount >= 4 ? 
-                `連勝每 ${requiredWins} 場（${requiredWins}、${requiredWins * 2}、${requiredWins * 3}...）可選擇加 1 分下場` :
-                '人數少於4人時，不啟用連勝休息機制'
-              }
+              連勝 {restRequirement} 場（{restRequirement}、{restRequirement * 2}、{restRequirement * 3}...）可選擇休息並額外得 1 分
             </p>
           </div>
         </div>
@@ -40,8 +66,8 @@ const GameRules = ({ playerCount = 4 }) => {
         <div className="rule-item">
           <div className="rule-icon">🔄</div>
           <div className="rule-content">
-            <h4>下場機制</h4>
-            <p>選擇加分下場後排到隊伍末尾，很快會重新上場</p>
+            <h4>休息機制</h4>
+            <p>休息選手會重新排隊，當無其他選手時自動返場</p>
           </div>
         </div>
         
@@ -63,8 +89,8 @@ const GameRules = ({ playerCount = 4 }) => {
       </div>
       
       <div className="rules-footer">
-        <p>💡 提示：連勝 {requiredWins} 場表示已打贏所有對手一輪，可選擇加分下場！</p>
-        <p>🔄 選擇下場不會離開比賽，只是排到隊伍後面等候</p>
+        <p>💡 提示：連勝 {restRequirement} 場表示已打贏所有對手一輪，可選擇休息！</p>
+        <p>🔄 休息不會離開比賽，只是暫時排隊等候下一輪</p>
       </div>
     </div>
   );

--- a/src/components/MainRouter.js
+++ b/src/components/MainRouter.js
@@ -1,106 +1,40 @@
+/**
+ * Simplified Main Router - Streak Tournament Only
+ * Simple routing between player setup and game modes
+ */
+
 import React from 'react';
 import { useGame } from '../contexts/GameContext';
-import { useRoomManager } from '../hooks/useRoomManager';
+import { APP_MODES } from '../constants';
 
 // Components
 import PlayerSetup from './PlayerSetup';
-import RoomBrowser from './RoomBrowser';
-import RoomHistory from './RoomHistory';
-
-// Containers
-import GameView from '../containers/GameView';
+import GameContainer from '../containers/GameContainer';
 
 /**
- * Main application router component
- * Handles navigation between different app views
+ * Main router component that handles app navigation
  */
 const MainRouter = () => {
-  const {
-    // State
-    appMode,
-    isMultiplayer,
-    isJoiningRoom,
-    
-    // Actions
-    setAppMode,
-    setupPlayers
-  } = useGame();
+  const { currentMode } = useGame();
 
-  // Room management (always enable Firebase for multiplayer features)
-  const {
-    roomCode,
-    isRoomHost,
-    roomConnected,
-    handleCreateRoom,
-    handleJoinRoom,
-    createRoomWithGameState
-  } = useRoomManager(true); // Enable Firebase
-
-  // Handle view history
-  const handleViewHistory = () => {
-    setAppMode('history');
-  };
-
-  // Handle player setup completion
-  const handleSetupPlayers = async (names, count) => {
-    // Setup players in context
-    setupPlayers(names, count);
-    
-    // If multiplayer mode, create Firebase room
-    if (isMultiplayer) {
-      console.log('Creating Firebase room after player setup');
-      // Wait a moment for state to update
-      setTimeout(async () => {
-        const success = await createRoomWithGameState();
-        if (success) {
-          console.log('Room created successfully');
-        } else {
-          console.log('Failed to create room, falling back to local mode');
-        }
-      }, 100);
-    }
-    
-    // Always go to game mode after player setup
-    setAppMode('game');
-  };
-
-  // Route to appropriate view based on app mode
-  const renderCurrentView = () => {
-    switch (appMode) {
-      case 'history':
-        return (
-          <RoomHistory onBack={() => setAppMode('room-browser')} />
-        );
+  const renderCurrentMode = () => {
+    switch (currentMode) {
+      case APP_MODES.PLAYER_SETUP:
+        return <PlayerSetup />;
       
-      case 'player-setup':
-        return (
-          <PlayerSetup 
-            onSetupPlayers={handleSetupPlayers}
-            onBack={() => setAppMode('room-browser')}
-            isMultiplayer={isMultiplayer}
-            roomCode={roomCode}
-            isRoomHost={isRoomHost}
-            roomConnected={roomConnected}
-          />
-        );
+      case APP_MODES.GAME:
+        return <GameContainer />;
       
-      case 'game':
-        return <GameView />;
-      
-      case 'room-browser':
       default:
-        return (
-          <RoomBrowser 
-            onJoinRoom={handleJoinRoom}
-            onCreateRoom={handleCreateRoom}
-            onViewHistory={handleViewHistory}
-            isLoading={isJoiningRoom}
-          />
-        );
+        return <PlayerSetup />;
     }
   };
 
-  return renderCurrentView();
+  return (
+    <div className="main-router">
+      {renderCurrentMode()}
+    </div>
+  );
 };
 
 export default MainRouter;

--- a/src/components/PlayerSetup.css
+++ b/src/components/PlayerSetup.css
@@ -1,535 +1,338 @@
-.setup-container {
+/* Player Setup Styles - Enhanced with Rules Preview */
+
+.player-setup {
   min-height: 100vh;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  color: white;
   padding: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.setup-card {
-  position: relative;
-  background: rgba(255, 255, 255, 0.95);
+.setup-container {
+  background: rgba(255, 255, 255, 0.1);
   border-radius: 20px;
   padding: 40px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(10px);
-  max-width: 600px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  max-width: 800px;
   width: 100%;
-  animation: slideIn 0.8s ease-out;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
 }
 
-@keyframes slideIn {
-  from {
-    opacity: 0;
-    transform: translateY(50px) scale(0.9);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
+/* Header */
 .setup-header {
   text-align: center;
   margin-bottom: 40px;
 }
 
-.setup-title {
-  font-size: 2.5em;
-  color: #333;
-  margin-bottom: 10px;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
-  animation: titleBounce 1s ease-out;
+.setup-header h1 {
+  margin: 0 0 15px 0;
+  font-size: 3em;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-@keyframes titleBounce {
-  0%, 20%, 50%, 80%, 100% {
-    transform: translateY(0);
-  }
-  40% {
-    transform: translateY(-10px);
-  }
-  60% {
-    transform: translateY(-5px);
-  }
+.setup-header p {
+  margin: 0;
+  opacity: 0.9;
+  font-size: 1.2em;
 }
 
-.setup-subtitle {
-  color: #666;
-  font-size: 1.1em;
-}
-
-/* Player Count Selection */
+/* Player Count Section */
 .player-count-section {
-  margin-bottom: 30px;
+  margin-bottom: 35px;
 }
 
 .player-count-section h3 {
-  font-size: 1.3em;
-  color: #333;
-  margin-bottom: 15px;
+  margin: 0 0 20px 0;
+  font-size: 1.5em;
   text-align: center;
 }
 
-.count-buttons {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+.player-count-buttons {
+  display: flex;
   gap: 10px;
-  margin-bottom: 15px;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .count-btn {
-  padding: 15px 20px;
-  border: 2px solid #e0e0e0;
-  border-radius: 15px;
-  background: white;
-  color: #333;
-  font-weight: bold;
-  font-size: 1.1em;
+  background: rgba(255, 255, 255, 0.15);
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  padding: 12px 20px;
+  border-radius: 25px;
   cursor: pointer;
   transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
+  font-size: 1.1em;
+  font-weight: bold;
+  min-width: 60px;
 }
 
 .count-btn:hover {
+  background: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.5);
   transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
 }
 
 .count-btn.active {
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  color: white;
-  border-color: #667eea;
-  animation: activeGlow 2s infinite;
+  background: linear-gradient(45deg, #4CAF50, #45a049);
+  border-color: #4CAF50;
+  box-shadow: 0 5px 15px rgba(76, 175, 80, 0.4);
+  transform: translateY(-2px);
 }
 
-@keyframes activeGlow {
-  0%, 100% {
-    box-shadow: 0 0 20px rgba(102, 126, 234, 0.4);
-  }
-  50% {
-    box-shadow: 0 0 30px rgba(102, 126, 234, 0.6);
-  }
+/* Rules Preview Section */
+.rules-preview {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 15px;
+  padding: 25px;
+  margin-bottom: 35px;
 }
 
-.count-info {
-  background: linear-gradient(45deg, #f093fb, #f5576c);
-  color: white;
-  padding: 12px 20px;
-  border-radius: 10px;
+.rules-preview h4 {
+  margin: 0 0 20px 0;
+  font-size: 1.3em;
   text-align: center;
-  font-weight: 500;
+  color: #4CAF50;
+}
+
+.rules-info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 15px;
+}
+
+.rules-info span {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 12px 15px;
+  border-radius: 10px;
+  border-left: 3px solid #4CAF50;
+  font-size: 0.95em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* Player Names Section */
-.names-section {
-  margin-bottom: 30px;
+.player-names-section {
+  margin-bottom: 35px;
 }
 
 .names-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 25px;
 }
 
 .names-header h3 {
-  font-size: 1.3em;
-  color: #333;
   margin: 0;
+  font-size: 1.5em;
 }
 
 .random-btn {
-  background: linear-gradient(45deg, #f39c12, #e67e22);
+  background: linear-gradient(45deg, #FF6B6B, #4ECDC4);
   color: white;
   border: none;
-  padding: 8px 15px;
+  padding: 10px 20px;
   border-radius: 20px;
-  font-weight: bold;
   cursor: pointer;
+  font-weight: bold;
   transition: all 0.3s ease;
-  font-size: 0.9em;
+  font-size: 0.95em;
 }
 
 .random-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(243, 156, 18, 0.3);
+  transform: scale(1.05);
+  box-shadow: 0 5px 15px rgba(255, 107, 107, 0.4);
 }
 
-.names-grid {
+/* Player Inputs */
+.player-inputs {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
 }
 
-.name-input-group {
+.player-input-group {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.name-input-group label {
+.player-input-group label {
   font-weight: bold;
-  color: #555;
-  font-size: 0.9em;
+  font-size: 1.1em;
+  color: #4CAF50;
 }
 
-.name-input-group input {
-  padding: 12px 15px;
-  border: 2px solid #e0e0e0;
-  border-radius: 10px;
-  font-size: 1em;
-  transition: all 0.3s ease;
-  background: white;
-}
-
-.name-input-group input:focus {
-  outline: none;
-  border-color: #667eea;
-  box-shadow: 0 0 10px rgba(102, 126, 234, 0.2);
-}
-
-.name-input-group input:not(:placeholder-shown) {
-  border-color: #27ae60;
-  background: linear-gradient(to right, #ffffff 0%, #f8fff8 100%);
-}
-
-/* Rules Preview */
-.rules-preview {
-  background: linear-gradient(45deg, #3498db, #2980b9);
+.player-input-group input {
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid rgba(255, 255, 255, 0.3);
   color: white;
-  padding: 20px;
-  border-radius: 15px;
-  margin-bottom: 30px;
+  padding: 12px 15px;
+  border-radius: 10px;
+  font-size: 1.1em;
+  transition: all 0.3s ease;
 }
 
-.rules-preview h4 {
-  margin-top: 0;
-  margin-bottom: 15px;
-  font-size: 1.2em;
+.player-input-group input:focus {
+  outline: none;
+  border-color: #4CAF50;
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 10px rgba(76, 175, 80, 0.3);
 }
 
-.rules-preview ul {
-  margin: 0;
-  padding-left: 20px;
-  list-style-type: none;
+.player-input-group input::placeholder {
+  color: rgba(255, 255, 255, 0.6);
 }
 
-.rules-preview li {
-  margin-bottom: 8px;
-  position: relative;
-  padding-left: 5px;
-}
-
-/* Start Game Button */
+/* Start Section */
 .start-section {
   text-align: center;
+  margin-bottom: 25px;
 }
 
-.start-game-btn {
-  background: linear-gradient(45deg, #27ae60, #2ecc71);
+.start-btn {
+  background: linear-gradient(45deg, #4CAF50, #45a049);
   color: white;
   border: none;
-  padding: 18px 40px;
-  border-radius: 25px;
-  font-size: 1.2em;
-  font-weight: bold;
+  padding: 15px 40px;
+  border-radius: 30px;
   cursor: pointer;
+  font-size: 1.3em;
+  font-weight: bold;
   transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  min-width: 200px;
+  box-shadow: 0 5px 15px rgba(76, 175, 80, 0.4);
 }
 
-.start-game-btn:hover {
+.start-btn:hover {
   transform: translateY(-3px);
-  box-shadow: 0 10px 25px rgba(39, 174, 96, 0.3);
+  box-shadow: 0 8px 25px rgba(76, 175, 80, 0.6);
 }
 
-.start-game-btn:active {
-  transform: translateY(0);
+.start-btn:active {
+  transform: translateY(-1px);
 }
 
-.start-game-btn::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
-  transition: left 0.5s;
-}
-
-.start-game-btn:hover::before {
-  left: 100%;
-}
-
-/* Loading Animation */
-.loading-animation {
+/* Setup Footer */
+.setup-footer {
   text-align: center;
-  padding: 60px 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  padding-top: 20px;
 }
 
-.loading-spinner {
-  width: 60px;
-  height: 60px;
-  border: 4px solid rgba(255, 255, 255, 0.3);
-  border-top: 4px solid white;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin: 0 auto 20px;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
-.loading-animation h2 {
-  color: white;
+.setup-footer p {
   margin: 0;
-  font-size: 1.5em;
-  animation: pulse 2s infinite;
+  opacity: 0.8;
+  font-size: 0.95em;
+  line-height: 1.5;
 }
 
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}
-
-/* Mobile Responsive */
+/* Responsive Design */
 @media (max-width: 768px) {
+  .player-setup {
+    padding: 15px;
+  }
+  
   .setup-container {
-    padding: 10px;
+    padding: 30px;
   }
   
-  .setup-card {
-    padding: 25px;
+  .setup-header h1 {
+    font-size: 2.5em;
   }
   
-  .setup-title {
-    font-size: 2em;
+  .setup-header p {
+    font-size: 1.1em;
   }
   
-  .count-buttons {
-    grid-template-columns: repeat(2, 1fr);
+  .player-count-buttons {
+    gap: 8px;
   }
   
-  .names-grid {
+  .count-btn {
+    padding: 10px 16px;
+    font-size: 1em;
+    min-width: 50px;
+  }
+  
+  .rules-info {
     grid-template-columns: 1fr;
+    gap: 12px;
   }
   
   .names-header {
     flex-direction: column;
     gap: 15px;
-    text-align: center;
+    align-items: center;
+  }
+  
+  .player-inputs {
+    grid-template-columns: 1fr;
+    gap: 15px;
+  }
+  
+  .start-btn {
+    padding: 12px 30px;
+    font-size: 1.2em;
   }
 }
 
 @media (max-width: 480px) {
-  .setup-card {
+  .setup-container {
     padding: 20px;
   }
   
-  .setup-title {
-    font-size: 1.8em;
-  }
-  
-  .count-buttons {
-    grid-template-columns: 1fr;
-  }
-  
-  .start-game-btn {
-    width: 100%;
-    padding: 15px;
-  }
-}
-
-.setup-actions {
-  display: flex;
-  justify-content: center;
-  margin-top: 30px;
-  padding: 0 20px;
-}
-
-.back-btn {
-  padding: 12px 25px;
-  border: none;
-  border-radius: 25px;
-  background: linear-gradient(45deg, #ff6b6b, #ff8787);
-  color: white;
-  font-size: 1.1em;
-  font-weight: bold;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.3);
-  min-width: 120px;
-}
-
-.back-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(255, 107, 107, 0.4);
-}
-
-.back-btn:active {
-  transform: translateY(0);
-}
-
-.start-btn {
-  padding: 12px 25px;
-  border: none;
-  border-radius: 25px;
-  background: linear-gradient(45deg, #4facfe, #00f2fe);
-  color: white;
-  font-size: 1.1em;
-  font-weight: bold;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(79, 172, 254, 0.3);
-  min-width: 120px;
-}
-
-.start-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(79, 172, 254, 0.4);
-}
-
-.start-btn:active {
-  transform: translateY(0);
-}
-
-.start-btn:disabled {
-  background: #cccccc;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-/* Mobile optimizations */
-@media (max-width: 768px) {
-  .setup-actions {
-    padding: 0 10px;
-  }
-
-  .back-btn,
-  .start-btn {
-    width: 100%;
-    padding: 12px 20px;
-  }
-}
-
-/* Floating back button */
-.back-btn.floating {
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  z-index: 100;
-  padding: 10px 20px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-radius: 25px;
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(10px);
-  color: #665555;
-  font-size: 1em;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.back-btn.floating:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
-}
-
-.back-btn.floating:active {
-  transform: translateY(0);
-}
-
-/* Room Info Styles */
-.room-info {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  padding: 20px;
-  border-radius: 15px;
-  margin: 20px 0;
-  text-align: center;
-  box-shadow: 0 10px 30px rgba(102, 126, 234, 0.3);
-}
-
-.room-code-display h3 {
-  margin: 0 0 15px 0;
-  font-size: 1.2em;
-  opacity: 0.9;
-}
-
-.room-code {
-  font-size: 2.5em;
-  font-weight: bold;
-  letter-spacing: 3px;
-  background: rgba(255, 255, 255, 0.2);
-  padding: 15px 20px;
-  border-radius: 10px;
-  margin: 15px 0;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  animation: codeGlow 2s infinite;
-  font-family: 'Courier New', monospace;
-}
-
-@keyframes codeGlow {
-  0%, 100% {
-    box-shadow: 0 0 15px rgba(255, 255, 255, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 25px rgba(255, 255, 255, 0.5);
-  }
-}
-
-.room-status {
-  margin: 10px 0;
-  font-size: 1em;
-  opacity: 0.9;
-}
-
-.room-hint {
-  margin: 10px 0 0 0;
-  font-size: 0.9em;
-  opacity: 0.8;
-  font-style: italic;
-}
-
-.room-creating {
-  padding: 15px;
-  opacity: 0.9;
-}
-
-.room-creating p {
-  margin: 0;
-  font-size: 1.1em;
-  animation: pulse 2s infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 0.7; }
-  50% { opacity: 1; }
-}
-
-/* Mobile optimizations for room info */
-@media (max-width: 768px) {
-  .room-info {
-    margin: 15px 0;
-    padding: 15px;
-  }
-  
-  .room-code {
+  .setup-header h1 {
     font-size: 2em;
-    letter-spacing: 2px;
-    padding: 12px 15px;
   }
   
-  .room-code-display h3 {
+  .player-count-buttons {
+    gap: 6px;
+  }
+  
+  .count-btn {
+    padding: 8px 12px;
+    font-size: 0.9em;
+    min-width: 45px;
+  }
+  
+  .rules-preview {
+    padding: 20px;
+  }
+  
+  .rules-info span {
+    padding: 10px 12px;
+    font-size: 0.9em;
+  }
+  
+  .player-input-group input {
+    padding: 10px 12px;
+    font-size: 1em;
+  }
+  
+  .start-btn {
+    padding: 10px 25px;
     font-size: 1.1em;
+  }
+}
+
+/* Animation */
+.setup-container > * {
+  animation: fadeInUp 0.6s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,16 +1,14 @@
 /**
- * Application configuration constants
+ * Application configuration constants - Simplified for Streak Tournament Only
  */
 
-// App version
-export const APP_VERSION = 'v1.5.6';
+// App version - Updated for simplified version
+export const APP_VERSION = 'v1.4.0';
 
-// App modes - duplicated from GameContext for consistency
+// App modes - Simplified to core functionality
 export const APP_MODES = {
-  ROOM_BROWSER: 'room-browser',
   PLAYER_SETUP: 'player-setup',
-  GAME: 'game',
-  HISTORY: 'history'
+  GAME: 'game'
 };
 
 // Status message types
@@ -21,19 +19,20 @@ export const STATUS_TYPES = {
   INFO: 'info'
 };
 
-// Game configuration defaults
+// Game configuration for streak tournament
 export const GAME_DEFAULTS = {
   DEFAULT_PLAYER_COUNT: 4,
-  MIN_PLAYER_COUNT: 2,
-  MAX_PLAYER_COUNT: 10,
-  DEFAULT_PLAYER_NAMES: ['選手A', '選手B', '選手C', '選手D']
+  MIN_PLAYER_COUNT: 3,
+  MAX_PLAYER_COUNT: 8,
+  DEFAULT_PLAYER_NAMES: ['選手A', '選手B', '選手C', '選手D', '選手E', '選手F', '選手G', '選手H']
 };
 
-// Firebase configuration
-export const FIREBASE_DEFAULTS = {
-  ROOM_CODE_LENGTH: 6,
-  MAX_ROOM_NAME_LENGTH: 50,
-  ROOM_EXPIRY_HOURS: 24
+// Streak tournament specific settings
+export const STREAK_CONFIG = {
+  // Consecutive wins needed for rest option = playerCount - 1
+  getRestRequirement: (playerCount) => playerCount - 1,
+  REST_BONUS_POINTS: 1,
+  POINTS_PER_WIN: 1
 };
 
 // UI configuration

--- a/src/containers/GameContainer.css
+++ b/src/containers/GameContainer.css
@@ -1,4 +1,4 @@
-/* Game Container Styles - Simplified Layout */
+/* Game Container Styles - Enhanced with Visual Flow */
 
 .game-container {
   min-height: 100vh;
@@ -8,6 +8,10 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.game-container.enhanced {
+  /* Enhanced version with better spacing */
 }
 
 .game-container.error {
@@ -73,6 +77,7 @@
   grid-template-columns: 1fr 1fr;
   gap: 20px;
   flex: 1;
+  min-height: 500px;
 }
 
 .game-left,
@@ -82,28 +87,27 @@
   gap: 20px;
 }
 
-/* Bottom panel */
+/* Bottom panel - Full width for history only */
 .game-bottom {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: 20px;
+  display: block;
   max-height: 300px;
 }
 
-.game-bottom-left,
-.game-bottom-right {
+.game-bottom-full {
   background: rgba(255, 255, 255, 0.1);
   border-radius: 15px;
   padding: 15px;
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   overflow-y: auto;
+  height: 100%;
 }
 
 /* Responsive design */
 @media (max-width: 1200px) {
   .game-main {
     grid-template-columns: 1fr;
+    min-height: auto;
   }
   
   .game-right {
@@ -144,12 +148,6 @@
   }
   
   .game-bottom {
-    grid-template-columns: 1fr;
-    max-height: none;
-  }
-  
-  .game-bottom-left,
-  .game-bottom-right {
     max-height: 250px;
   }
 }
@@ -183,7 +181,7 @@
   }
   
   .game-bottom {
-    gap: 10px;
+    max-height: 200px;
   }
 }
 
@@ -204,24 +202,20 @@
 }
 
 /* Scrollbar styling */
-.game-bottom-left::-webkit-scrollbar,
-.game-bottom-right::-webkit-scrollbar {
+.game-bottom-full::-webkit-scrollbar {
   width: 8px;
 }
 
-.game-bottom-left::-webkit-scrollbar-track,
-.game-bottom-right::-webkit-scrollbar-track {
+.game-bottom-full::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.1);
   border-radius: 4px;
 }
 
-.game-bottom-left::-webkit-scrollbar-thumb,
-.game-bottom-right::-webkit-scrollbar-thumb {
+.game-bottom-full::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.3);
   border-radius: 4px;
 }
 
-.game-bottom-left::-webkit-scrollbar-thumb:hover,
-.game-bottom-right::-webkit-scrollbar-thumb:hover {
+.game-bottom-full::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.5);
 }

--- a/src/containers/GameContainer.css
+++ b/src/containers/GameContainer.css
@@ -1,0 +1,227 @@
+/* Game Container Styles - Simplified Layout */
+
+.game-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.game-container.error {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.game-container.error h2 {
+  margin-bottom: 20px;
+  font-size: 2em;
+}
+
+.game-container.error button {
+  padding: 12px 24px;
+  background: #ff6b6b;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1.1em;
+  transition: background 0.3s ease;
+}
+
+.game-container.error button:hover {
+  background: #ff5252;
+}
+
+/* Header */
+.game-header {
+  text-align: center;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 20px;
+  border-radius: 15px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.game-header h1 {
+  margin: 0 0 15px 0;
+  font-size: 2.5em;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.game-info {
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  flex-wrap: wrap;
+  font-size: 1.1em;
+}
+
+.game-info span {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+/* Main game area */
+.game-main {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  flex: 1;
+}
+
+.game-left,
+.game-right {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Bottom panel */
+.game-bottom {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 20px;
+  max-height: 300px;
+}
+
+.game-bottom-left,
+.game-bottom-right {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 15px;
+  padding: 15px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  overflow-y: auto;
+}
+
+/* Responsive design */
+@media (max-width: 1200px) {
+  .game-main {
+    grid-template-columns: 1fr;
+  }
+  
+  .game-right {
+    flex-direction: row;
+    gap: 20px;
+  }
+  
+  .game-right > * {
+    flex: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .game-container {
+    padding: 10px;
+    gap: 15px;
+  }
+  
+  .game-header h1 {
+    font-size: 2em;
+  }
+  
+  .game-info {
+    gap: 15px;
+    font-size: 0.9em;
+  }
+  
+  .game-info span {
+    padding: 6px 12px;
+  }
+  
+  .game-main {
+    gap: 15px;
+  }
+  
+  .game-right {
+    flex-direction: column;
+  }
+  
+  .game-bottom {
+    grid-template-columns: 1fr;
+    max-height: none;
+  }
+  
+  .game-bottom-left,
+  .game-bottom-right {
+    max-height: 250px;
+  }
+}
+
+@media (max-width: 480px) {
+  .game-container {
+    padding: 5px;
+    gap: 10px;
+  }
+  
+  .game-header {
+    padding: 15px;
+  }
+  
+  .game-header h1 {
+    font-size: 1.8em;
+  }
+  
+  .game-info {
+    flex-direction: column;
+    gap: 10px;
+  }
+  
+  .game-main {
+    gap: 10px;
+  }
+  
+  .game-left,
+  .game-right {
+    gap: 10px;
+  }
+  
+  .game-bottom {
+    gap: 10px;
+  }
+}
+
+/* Animations */
+.game-container > * {
+  animation: fadeInUp 0.6s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Scrollbar styling */
+.game-bottom-left::-webkit-scrollbar,
+.game-bottom-right::-webkit-scrollbar {
+  width: 8px;
+}
+
+.game-bottom-left::-webkit-scrollbar-track,
+.game-bottom-right::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.game-bottom-left::-webkit-scrollbar-thumb,
+.game-bottom-right::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+}
+
+.game-bottom-left::-webkit-scrollbar-thumb:hover,
+.game-bottom-right::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.5);
+}

--- a/src/containers/GameContainer.js
+++ b/src/containers/GameContainer.js
@@ -1,6 +1,6 @@
 /**
- * Simplified Game Container - Streak Tournament Only
- * Main game interface with all game components
+ * Simplified Game Container - Enhanced Visual Flow
+ * Main game interface without rules (moved to setup page)
  */
 
 import React from 'react';
@@ -12,7 +12,6 @@ import PlayerQueue from '../components/PlayerQueue';
 import Scoreboard from '../components/Scoreboard';
 import GameControls from '../components/GameControls';
 import GameHistory from '../components/GameHistory';
-import GameRules from '../components/GameRules';
 
 // Styles
 import './GameContainer.css';
@@ -48,8 +47,19 @@ const GameContainer = () => {
   const currentMatch = getCurrentMatch();
   const leaderboard = getLeaderboard();
 
+  // Get next player in queue for visual preview
+  const getNextPlayerInQueue = () => {
+    if (!gameState.players) return null;
+    
+    // Find players who are not currently active and not resting
+    const queuedPlayers = gameState.players.filter(p => !p.isActive && !p.isResting);
+    return queuedPlayers.length > 0 ? queuedPlayers[0] : null;
+  };
+
+  const nextPlayerInQueue = getNextPlayerInQueue();
+
   return (
-    <div className="game-container">
+    <div className="game-container enhanced">
       {/* Header with game info */}
       <div className="game-header">
         <h1>🥊 連勝競技系統</h1>
@@ -62,7 +72,7 @@ const GameContainer = () => {
 
       {/* Main game area */}
       <div className="game-main">
-        {/* Left panel - Arena and Controls */}
+        {/* Left panel - Enhanced Arena */}
         <div className="game-left">
           <GameArena 
             currentMatch={currentMatch}
@@ -70,6 +80,8 @@ const GameContainer = () => {
             canTakeRest={(playerName) => canPlayerRest(playerName)}
             onTakeRest={takeRest}
             isGameFinished={gameState.isGameFinished}
+            players={gameState.players}
+            nextPlayerInQueue={nextPlayerInQueue}
           />
           
           <GameControls
@@ -87,6 +99,7 @@ const GameContainer = () => {
           <PlayerQueue 
             players={gameState.players}
             currentMatch={currentMatch}
+            nextPlayerInQueue={nextPlayerInQueue}
           />
           
           <Scoreboard 
@@ -96,20 +109,12 @@ const GameContainer = () => {
         </div>
       </div>
 
-      {/* Bottom panel - History and Rules */}
+      {/* Bottom panel - History only (rules moved to setup) */}
       <div className="game-bottom">
-        <div className="game-bottom-left">
+        <div className="game-bottom-full">
           <GameHistory 
             history={gameState.gameHistory}
             players={gameState.players}
-          />
-        </div>
-        
-        <div className="game-bottom-right">
-          <GameRules 
-            playerCount={gameState.players.length}
-            restRequirement={gameState.restRequirement}
-            compact={true}
           />
         </div>
       </div>

--- a/src/containers/GameContainer.js
+++ b/src/containers/GameContainer.js
@@ -1,0 +1,120 @@
+/**
+ * Simplified Game Container - Streak Tournament Only
+ * Main game interface with all game components
+ */
+
+import React from 'react';
+import { useGame } from '../contexts/GameContext';
+
+// Components
+import GameArena from '../components/GameArena';
+import PlayerQueue from '../components/PlayerQueue';
+import Scoreboard from '../components/Scoreboard';
+import GameControls from '../components/GameControls';
+import GameHistory from '../components/GameHistory';
+import GameRules from '../components/GameRules';
+
+// Styles
+import './GameContainer.css';
+
+/**
+ * Main game container that displays all game components
+ */
+const GameContainer = () => {
+  const { 
+    gameState, 
+    getCurrentMatch, 
+    getLeaderboard,
+    declareWinner,
+    takeRest,
+    undoLastAction,
+    resetGame,
+    endGame,
+    setMode,
+    canPlayerRest
+  } = useGame();
+
+  if (!gameState) {
+    return (
+      <div className="game-container error">
+        <h2>遊戲尚未開始</h2>
+        <button onClick={() => setMode('player-setup')}>
+          返回設置
+        </button>
+      </div>
+    );
+  }
+
+  const currentMatch = getCurrentMatch();
+  const leaderboard = getLeaderboard();
+
+  return (
+    <div className="game-container">
+      {/* Header with game info */}
+      <div className="game-header">
+        <h1>🥊 連勝競技系統</h1>
+        <div className="game-info">
+          <span>參賽人數: {gameState.players.length}人</span>
+          <span>連勝休息: {gameState.restRequirement}場</span>
+          <span>比賽場次: {gameState.gameHistory.filter(h => h.winner).length}</span>
+        </div>
+      </div>
+
+      {/* Main game area */}
+      <div className="game-main">
+        {/* Left panel - Arena and Controls */}
+        <div className="game-left">
+          <GameArena 
+            currentMatch={currentMatch}
+            onDeclareWinner={declareWinner}
+            canTakeRest={(playerName) => canPlayerRest(playerName)}
+            onTakeRest={takeRest}
+            isGameFinished={gameState.isGameFinished}
+          />
+          
+          <GameControls
+            onUndo={undoLastAction}
+            onReset={resetGame}
+            onEndGame={endGame}
+            onBackToSetup={() => setMode('player-setup')}
+            canUndo={gameState.gameHistory.length > 0}
+            isGameFinished={gameState.isGameFinished}
+          />
+        </div>
+
+        {/* Right panel - Queue and Scoreboard */}
+        <div className="game-right">
+          <PlayerQueue 
+            players={gameState.players}
+            currentMatch={currentMatch}
+          />
+          
+          <Scoreboard 
+            players={leaderboard}
+            isGameFinished={gameState.isGameFinished}
+          />
+        </div>
+      </div>
+
+      {/* Bottom panel - History and Rules */}
+      <div className="game-bottom">
+        <div className="game-bottom-left">
+          <GameHistory 
+            history={gameState.gameHistory}
+            players={gameState.players}
+          />
+        </div>
+        
+        <div className="game-bottom-right">
+          <GameRules 
+            playerCount={gameState.players.length}
+            restRequirement={gameState.restRequirement}
+            compact={true}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GameContainer;

--- a/src/gameEngines/StreakGameEngine.js
+++ b/src/gameEngines/StreakGameEngine.js
@@ -1,6 +1,6 @@
 /**
  * Simplified Streak Tournament Game Engine
- * Focus only on streak-based tournament functionality
+ * Focus only on streak-based tournament functionality with enhanced visual support
  */
 
 import { STREAK_CONFIG } from '../constants';
@@ -139,8 +139,16 @@ export class StreakGameEngine {
       isGameStarted: this.isGameStarted,
       isGameFinished: this.isGameFinished,
       restRequirement: this.restRequirement,
-      leaderboard: this._getLeaderboard()
+      leaderboard: this._getLeaderboard(),
+      nextPlayerInQueue: this._getNextPlayer()
     };
+  }
+
+  /**
+   * Get next player in queue for visual preview
+   */
+  getNextPlayerInQueue() {
+    return this._getNextPlayer();
   }
 
   /**
@@ -215,7 +223,7 @@ export class StreakGameEngine {
   }
 
   _getNextPlayer() {
-    return this.players.find(p => !p.isActive && !p.isResting);
+    return this.players.find(p => !p.isActive && !p.isResting) || null;
   }
 
   _handleNoAvailablePlayers(currentWinner) {

--- a/src/gameEngines/StreakGameEngine.js
+++ b/src/gameEngines/StreakGameEngine.js
@@ -1,0 +1,328 @@
+/**
+ * Simplified Streak Tournament Game Engine
+ * Focus only on streak-based tournament functionality
+ */
+
+import { STREAK_CONFIG } from '../constants';
+
+export class StreakGameEngine {
+  constructor(players) {
+    // Validate input
+    if (!Array.isArray(players) || players.length < 3) {
+      throw new Error('At least 3 players required for streak tournament');
+    }
+
+    this.players = players.map((name, index) => ({
+      id: index,
+      name: name.trim(),
+      score: 0,
+      currentStreak: 0,
+      totalWins: 0,
+      totalLosses: 0,
+      isActive: index < 2, // First two players start
+      isResting: false,
+      position: index
+    }));
+
+    this.gameHistory = [];
+    this.currentMatch = {
+      player1: this.players[0],
+      player2: this.players[1]
+    };
+    this.isGameStarted = true;
+    this.isGameFinished = false;
+    this.restRequirement = STREAK_CONFIG.getRestRequirement(players.length);
+  }
+
+  /**
+   * Process match result when a player wins
+   */
+  declareWinner(winnerName) {
+    const winner = this.players.find(p => p.name === winnerName);
+    const loser = this.currentMatch.player1.name === winnerName 
+      ? this.currentMatch.player2 
+      : this.currentMatch.player1;
+
+    if (!winner || !loser) {
+      throw new Error('Invalid winner name');
+    }
+
+    // Update winner stats
+    winner.score += STREAK_CONFIG.POINTS_PER_WIN;
+    winner.currentStreak += 1;
+    winner.totalWins += 1;
+
+    // Update loser stats
+    loser.currentStreak = 0;
+    loser.totalLosses += 1;
+
+    // Record match in history
+    this.gameHistory.push({
+      id: this.gameHistory.length + 1,
+      winner: winner.name,
+      loser: loser.name,
+      timestamp: Date.now(),
+      winnerScore: winner.score,
+      winnerStreak: winner.currentStreak
+    });
+
+    // Setup next match
+    this._setupNextMatch(winner, loser);
+
+    return {
+      winner,
+      loser,
+      canTakeRest: winner.currentStreak >= this.restRequirement && winner.currentStreak % this.restRequirement === 0
+    };
+  }
+
+  /**
+   * Handle player taking rest (when eligible)
+   */
+  takeRest(playerName) {
+    const player = this.players.find(p => p.name === playerName);
+    
+    if (!player) {
+      throw new Error('Player not found');
+    }
+
+    if (player.currentStreak < this.restRequirement || player.currentStreak % this.restRequirement !== 0) {
+      throw new Error('Player not eligible for rest');
+    }
+
+    // Give bonus points and mark as resting
+    player.score += STREAK_CONFIG.REST_BONUS_POINTS;
+    player.isResting = true;
+    player.isActive = false;
+
+    // Record rest in history
+    this.gameHistory.push({
+      id: this.gameHistory.length + 1,
+      action: 'rest',
+      player: player.name,
+      timestamp: Date.now(),
+      bonusPoints: STREAK_CONFIG.REST_BONUS_POINTS,
+      newScore: player.score
+    });
+
+    // Setup next match without the resting player
+    this._setupNextMatchAfterRest();
+  }
+
+  /**
+   * Undo last action
+   */
+  undoLastAction() {
+    if (this.gameHistory.length === 0) {
+      throw new Error('No actions to undo');
+    }
+
+    const lastAction = this.gameHistory.pop();
+    
+    if (lastAction.action === 'rest') {
+      this._undoRest(lastAction);
+    } else {
+      this._undoMatch(lastAction);
+    }
+
+    return lastAction;
+  }
+
+  /**
+   * Get current game state
+   */
+  getGameState() {
+    return {
+      players: this.players,
+      currentMatch: this.currentMatch,
+      gameHistory: this.gameHistory,
+      isGameStarted: this.isGameStarted,
+      isGameFinished: this.isGameFinished,
+      restRequirement: this.restRequirement,
+      leaderboard: this._getLeaderboard()
+    };
+  }
+
+  /**
+   * Reset game to initial state
+   */
+  resetGame() {
+    this.players.forEach((player, index) => {
+      player.score = 0;
+      player.currentStreak = 0;
+      player.totalWins = 0;
+      player.totalLosses = 0;
+      player.isActive = index < 2;
+      player.isResting = false;
+      player.position = index;
+    });
+
+    this.gameHistory = [];
+    this.currentMatch = {
+      player1: this.players[0],
+      player2: this.players[1]
+    };
+    this.isGameFinished = false;
+  }
+
+  /**
+   * End game manually
+   */
+  endGame() {
+    this.isGameFinished = true;
+    this.players.forEach(player => {
+      player.isActive = false;
+    });
+  }
+
+  // Private methods
+
+  _setupNextMatch(winner, loser) {
+    // Winner stays, loser goes to back of queue
+    loser.isActive = false;
+    
+    // Find next player in queue
+    const nextPlayer = this._getNextPlayer();
+    
+    if (nextPlayer) {
+      nextPlayer.isActive = true;
+      this.currentMatch = {
+        player1: winner,
+        player2: nextPlayer
+      };
+    } else {
+      // No more players available, handle resting players
+      this._handleNoAvailablePlayers(winner);
+    }
+  }
+
+  _setupNextMatchAfterRest() {
+    // Find two available players
+    const availablePlayers = this.players.filter(p => !p.isResting && !p.isActive);
+    
+    if (availablePlayers.length >= 2) {
+      availablePlayers[0].isActive = true;
+      availablePlayers[1].isActive = true;
+      
+      this.currentMatch = {
+        player1: availablePlayers[0],
+        player2: availablePlayers[1]
+      };
+    } else {
+      // Bring back resting players if needed
+      this._bringBackRestingPlayers();
+    }
+  }
+
+  _getNextPlayer() {
+    return this.players.find(p => !p.isActive && !p.isResting);
+  }
+
+  _handleNoAvailablePlayers(currentWinner) {
+    // If all other players are resting, bring them back
+    const restingPlayers = this.players.filter(p => p.isResting);
+    if (restingPlayers.length > 0) {
+      restingPlayers.forEach(player => {
+        player.isResting = false;
+      });
+      
+      const nextPlayer = this._getNextPlayer();
+      if (nextPlayer) {
+        nextPlayer.isActive = true;
+        this.currentMatch = {
+          player1: currentWinner,
+          player2: nextPlayer
+        };
+      }
+    }
+  }
+
+  _bringBackRestingPlayers() {
+    this.players.forEach(player => {
+      if (player.isResting) {
+        player.isResting = false;
+      }
+    });
+    
+    // Setup match with available players
+    const availablePlayers = this.players.filter(p => !p.isActive);
+    if (availablePlayers.length >= 2) {
+      availablePlayers[0].isActive = true;
+      availablePlayers[1].isActive = true;
+      
+      this.currentMatch = {
+        player1: availablePlayers[0],
+        player2: availablePlayers[1]
+      };
+    }
+  }
+
+  _undoMatch(lastAction) {
+    const winner = this.players.find(p => p.name === lastAction.winner);
+    const loser = this.players.find(p => p.name === lastAction.loser);
+
+    // Revert winner stats
+    winner.score -= STREAK_CONFIG.POINTS_PER_WIN;
+    winner.currentStreak -= 1;
+    winner.totalWins -= 1;
+
+    // Revert loser stats
+    loser.totalLosses -= 1;
+    
+    // Recalculate loser's streak from history
+    loser.currentStreak = this._calculateStreakFromHistory(loser.name);
+
+    // Restore match state
+    winner.isActive = true;
+    loser.isActive = true;
+    this.currentMatch = {
+      player1: winner,
+      player2: loser
+    };
+  }
+
+  _undoRest(lastAction) {
+    const player = this.players.find(p => p.name === lastAction.player);
+    
+    // Revert rest
+    player.score -= STREAK_CONFIG.REST_BONUS_POINTS;
+    player.isResting = false;
+    player.isActive = true;
+    
+    // Find opponent for current match
+    const opponent = this._getNextPlayer();
+    if (opponent) {
+      opponent.isActive = true;
+      this.currentMatch = {
+        player1: player,
+        player2: opponent
+      };
+    }
+  }
+
+  _calculateStreakFromHistory(playerName) {
+    let streak = 0;
+    for (let i = this.gameHistory.length - 1; i >= 0; i--) {
+      const action = this.gameHistory[i];
+      if (action.winner === playerName) {
+        streak++;
+      } else if (action.loser === playerName) {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  _getLeaderboard() {
+    return [...this.players]
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        if (b.currentStreak !== a.currentStreak) return b.currentStreak - a.currentStreak;
+        return b.totalWins - a.totalWins;
+      })
+      .map((player, index) => ({
+        ...player,
+        rank: index + 1
+      }));
+  }
+}


### PR DESCRIPTION
# 🎯 簡化連勝賽制系統 v1.4.0

## 📋 更新概要

根據你的要求，我完全簡化了競技系統，專注於**連勝賽制**，並實現了**視覺化比賽流程**。

## ✨ 主要改進

### 🎮 視覺化比賽流程
- **直觀預覽**: 滑鼠懸停選手可看到「如果他獲勝會怎樣」
- **清楚顯示**: 勝利後的人員變動、下一場對戰安排
- **點擊操作**: 移除左右勝利按鈕，改為直接點擊選手
- **流程說明**: 顯示勝者留場/敗者排隊/下一位上場

### 🏗️ 系統簡化
- **移除複雜賽制**: 刪除淘汰賽、循環賽等複雜功能
- **專注連勝**: 只保留連勝賽制，做到最好
- **簡化架構**: 重構代碼，移除不必要的複雜性
- **規則移動**: 比賽規則從房間移到設置頁面

### 🎨 UI/UX 優化
- **視覺回饋**: 懸停效果、動畫效果
- **流程預覽**: 實時顯示比賽結果預測
- **下一位提示**: 清楚顯示下一位上場選手
- **休息選擇**: 符合條件時顯示休息按鈕

## 🔧 技術改進

### 核心組件
- **StreakGameEngine**: 簡化的連勝賽制引擎
- **GameArena**: 增強的視覺化競技場
- **PlayerSetup**: 加入規則預覽的設置頁面
- **GameContainer**: 簡化的遊戲容器

### 移除功能
- ❌ 複雜的賽制選擇器
- ❌ 淘汰賽/循環賽引擎
- ❌ 房間瀏覽器功能
- ❌ 過度複雜的管理器

## 🎯 用戶體驗

### 設置頁面
- 選擇3-8人參賽
- 即時規則預覽
- 清楚的連勝說明
- 隨機名稱生成

### 比賽房間
- 直接點擊選手宣布勝利
- 懸停預覽比賽結果
- 清楚顯示下一位上場
- 休息機制一目了然

## 📁 檔案變更

### 新增檔案
- `src/gameEngines/StreakGameEngine.js` - 簡化連勝引擎
- `src/containers/GameContainer.js` - 簡化遊戲容器
- `src/containers/GameContainer.css` - 容器樣式

### 主要修改
- `src/constants/index.js` - 簡化常數設定
- `src/contexts/GameContext.js` - 簡化遊戲狀態管理
- `src/components/MainRouter.js` - 移除複雜路由
- `src/components/GameArena.js` - 增強視覺化界面
- `src/components/GameArena.css` - 新增流程預覽樣式
- `src/components/PlayerSetup.js` - 加入規則預覽
- `src/components/PlayerSetup.css` - 增強設置頁面樣式
- `src/components/GameRules.js` - 簡化規則組件

## 🚀 版本特色

### v1.4.0 - 簡化專精版
- 🎯 **專注連勝**: 移除所有其他賽制，專精連勝
- 👁️ **視覺化流程**: 一目了然的比賽進行方式
- 🖱️ **直觀操作**: 點擊選手即可宣布勝利
- 📋 **規則整合**: 設置時就能清楚了解規則
- 🎨 **UI 優化**: 更美觀、更流暢的使用體驗

## 🎮 操作方式

1. **設置階段**: 選擇人數 → 輸入名稱 → 查看規則預覽
2. **比賽階段**: 懸停選手查看預覽 → 點擊選手宣布勝利
3. **休息機制**: 連勝達標時自動顯示休息選項
4. **流程清晰**: 隨時知道下一位上場是誰

## 📱 響應式支援

- 桌面端：完整的視覺化預覽
- 平板端：適應性布局調整
- 手機端：簡化但保持功能完整

---

**這個版本專注於把連勝賽制做到最好，移除了所有不必要的複雜性，提供最直觀的比賽體驗！** 🏆